### PR TITLE
Stringify JSON for transport, parse on client

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ Here's how you'd start building an app based on this method:
           // this is split out so we have a reference to it we can
           // bind and unbind on disconnect.
           function sendClientChanges(changes) {
-            client.send(changes);
+	    client.send(JSON.stringify(changes));
           }
             
           // I blast out the client templates this way, just cause we can.

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ MIT Licensed.
     
 ##Introduction !important
 
-Capsule presents and experimental approach to building real-time web apps that re-uses the exact same models on the server as what you serve in a script tag in the html of your app. I've used this approach for a couple of apps, one of which our team uses everyday.
+Capsule presents an experimental approach to building real-time web apps that re-uses the exact same models on the server as what you serve in a script tag in the html of your app. I've used this approach for a couple of apps, one of which our team uses everyday.
 
 For more information on this approach see my blog post on [Re-using Backbone.js Models on the server with Node.js and Socket.io to build realtime apps](http://andyet.net/blog/2011/feb/15/re-using-backbonejs-models-on-the-server-with-node/). It's also something I will discuss it in my upcoming talk at [NodeConf 2011](http://nodeconf.com/).
 

--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,9 @@ Here's how you'd start building an app based on this method:
             var changedModel, template;
             
             console.log('RECD:', data);
-            
+
+            data = JSON.parse(data);            
+
             switch (data.event) {
               case 'templates':
                 for (template in data.templates) {


### PR DESCRIPTION
I've used the "alpha" of this code from Henrik's blog, and also in Capsule.js - the example code does not explicitly stringify() objects before transport, which means objects are inaccessible on the client side. I presume this is unintentional, or have I missed some magic serialisation?

Also corrected a typo :)
