### PR TITLE
improve desist of a view

### DIFF
--- a/capsule.js
+++ b/capsule.js
@@ -715,13 +715,13 @@
         views[model.cid] = new ViewClass(_({model: model}).extend(options));
         views[model.cid].parent = self;
       });
-      this.bindomatic(collection, 'remove', function (model) {
-        views[model.cid].desist();
+      this.bindomatic(collection, 'remove', function (model, collection, opts) {
+        views[model.cid].desist(opts);
         delete views[model.cid];
       });
-      this.bindomatic(collection, 'refresh', function () {
+      this.bindomatic(collection, 'refresh', function (opts) {
         _(views).each(function (view) {
-          view.desist();
+          view.desist(opts);
         });
         views = {};
         collection.each(function (model) {

--- a/capsule.js
+++ b/capsule.js
@@ -556,6 +556,7 @@
       }
       if (opts.quick) {
         $(this.el).unbind().remove();
+        this.unbindomatic();
       } else {
         $(this.el).animate({
             height: 0,
@@ -563,6 +564,7 @@
           },
           function () {
             $(this).unbind().remove();
+            this.unbindomatic();
           }
         );
       }


### PR DESCRIPTION
There is 2 things on this pull request :
- Keeping the options passed to an event when calling desist, so we can use the quick desist mode.
- unbinding bindomatic events when doing a view desist. Without this, it can create some issues after the refresh of a collection for exemple.
